### PR TITLE
fix: remove diagonal movement

### DIFF
--- a/Assets/Player/player.gd
+++ b/Assets/Player/player.gd
@@ -28,25 +28,29 @@ func _physics_process(delta: float) -> void:
 	_turn_head(delta)
 
 func _move_tile(delta):
+	if is_turning: return
 	if is_moving:
 		var next_move_amount = move_toward(move_amount, TILE_SIZE, MOVE_SPEED  * delta)
 		position += (next_move_amount - move_amount) * move_direction * delta
 		move_amount = next_move_amount
-		if move_amount >= TILE_SIZE:
+		if move_amount == TILE_SIZE:
 			move_amount = 0.0
 			is_moving = false
 		return;
 	
-	# Prioritise forward move over side moves - do not allow diagonals
-	var move_input_v := Input.get_axis("up", "down");
-	var move_input_h := Input.get_axis("left", "right")
+	var move_input_v = Input.get_axis("up", "down");
+	var move_input_h = Input.get_axis("left", "right")
 	
-	if move_input_v != 0.0 || move_input_h:
-		move_direction = (head.transform.basis * Vector3(move_input_h, 0, move_input_v)).normalized()
+	if move_input_v || move_input_h:
+		# Prioritise forward move over side moves - do not allow diagonals
+		var base_vector = Vector3(0.0 if move_input_v else move_input_h, 0.0, move_input_v)
+		
+		move_direction = (head.transform.basis * base_vector).normalized()
 		is_moving = true
 		return
 
 func _turn_head(delta: float):
+	if is_moving: return
 	# Turning cooldown
 	if is_turning:
 		var next_turn_amount = move_toward(turn_rotation_amount, 90, TURN_SPEED * delta)

--- a/Levels/level.tscn
+++ b/Levels/level.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://dvfg7eq1a00s2" path="res://Assets/Player/player.tscn" id="1_s41d2"]
 [ext_resource type="Script" uid="uid://cjq6hjyjcbwxh" path="res://Levels/minimap.gd" id="2_gtnvv"]
-[ext_resource type="PackedScene" uid="uid://be0lmohgkj2qu" path="res://Assets/Timer/timer_text.tscn" id="3_wav5q"]
+[ext_resource type="PackedScene" uid="uid://b0bxqku4pcb01" path="res://Assets/Timer/timer_text.tscn" id="3_wav5q"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_s41d2"]
 sky_horizon_color = Color(0.662243, 0.671743, 0.686743, 1)


### PR DESCRIPTION
Restricted movement to allow only horizontal or vertical movement, enforcing the priority for vertical movement

Restricted player state to be either movement or rotation, never both